### PR TITLE
Fixes for Grand Illusion parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
     - id: flake8
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
       name: isort (python)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="filmcalendar",
-    version="1.1.0",
+    version="1.1.1",
     description="Film calendar aggregator",
     author="Bryant Durrell",
     author_email="durrell@innocence.com",


### PR DESCRIPTION
1. The formatting for the film duration info changed, so added some regular expressions to make it a bit more resilient and modified the HTML parsing to find the right string again. This makes the crawling a bit slower and I don't actually have any reason to think I'll need the resilience, but better safe than sorry.

2. They added a special event that had a location of the format "<time> at <location>" so I added a check to handle that special case.

Also I had to update isort's version so that's a tagalong change.

Fixes #28, fixes #30.
