### PR TITLE
Another Grand Illusion location fix

### DIFF
--- a/src/filmcalendar/seattle/grandillusion.py
+++ b/src/filmcalendar/seattle/grandillusion.py
@@ -32,9 +32,8 @@ class FilmCalendarGrandIllusion(filmcalendar.FilmCalendar):
 
         soup = BeautifulSoup(req.text, "html.parser")
 
-        film_location = f"{self.theater}: {self.address}"
-
         for film in soup.find_all("div", class_="film-teaser"):
+            film_location = f"{self.theater}: {self.address}"
             try:
                 film_h2 = film.find("h2", class_="film-teaser--title")
                 film_title = film_h2.get_text()


### PR DESCRIPTION
I set film_location once -- since the first fix reset the location, I needed to reset the variable every time through the loop. Whoops.

Tested locally, looks OK now.

Fixes #33.
