### PR TITLE
Fix title casing for The Beacon

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="filmcalendar",
-    version="1.1.4",
+    version="1.1.5",
     description="Film calendar aggregator",
     author="Bryant Durrell",
     author_email="durrell@innocence.com",

--- a/src/filmcalendar/seattle/thebeacon.py
+++ b/src/filmcalendar/seattle/thebeacon.py
@@ -1,3 +1,4 @@
+import string
 from datetime import datetime, timedelta
 
 import requests
@@ -24,7 +25,9 @@ class FilmCalendarTheBeacon(filmcalendar.FilmCalendar):
 
         for film in soup.find_all("section", class_="showtime"):
             try:
-                film_title = film.find("section", itemprop="name").get_text().title()
+                film_title = string.capwords(
+                    film.find("section", itemprop="name").get_text()
+                )
             except TypeError as error:
                 raise ValueError("Couldn't find film name") from error
             if film_title != "Rent The Beacon":


### PR DESCRIPTION
Using title() on the film title was causing problems with titles
that included apostrophes, like "The Devil's Backbone".  Switched
to string.capwords(). Fixes #31.