### PR TITLE
SIFF 2024 fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="filmcalendar",
-    version="1.2.0",
+    version="1.2.1",
     description="Film calendar aggregator",
     author="Bryant Durrell",
     author_email="durrell@innocence.com",

--- a/src/filmcalendar/seattle/siff.py
+++ b/src/filmcalendar/seattle/siff.py
@@ -21,6 +21,8 @@ class FilmCalendarSIFF(filmcalendar.FilmCalendar):
             "AMC Pacific Place": "600 Pine St #400, Seattle, WA 98101",
             "Ark Lodge Cinemas": "4816 Rainier Ave S, Seattle, WA 98118",
             "Shoreline Community College": "16101 Greenwood Ave N. (Building 1600), Shoreline, WA 98133",  # NOQA
+            # New location for SIFF 2024
+            "Majestic Bay": "2044 NW Market St, Seattle, WA 98107",
         }
         self.base_url = "https://www.siff.net"
 


### PR DESCRIPTION
SIFF 2024 added Majestic Bay as a venue. I should probably avoid crashing out when venues aren't found, but later.

Fixes #71 .