### PR TITLE
Add main entrypoint to film_calendar

### DIFF
--- a/src/filmcalendar/scripts/film_calendar.py
+++ b/src/filmcalendar/scripts/film_calendar.py
@@ -88,3 +88,6 @@ def cli(config, theater, directory):
 
     films.write(f"{directory}/film_calendar.ics")
     films.writerss(f"{directory}/film_calendar.rss")
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
This makes it easy to run the script with something like `PYTHONPATH=src python3 -m filmcalendar.scripts.film_calendar` while developing.