### PR TITLE
Fix xxhash 4.0.0 incompatibility in UID generation

### DIFF
--- a/src/filmcalendar/filmcalendar.py
+++ b/src/filmcalendar/filmcalendar.py
@@ -80,7 +80,7 @@ class FilmCalendar:
         event.add("dtstamp", vDatetime(datetime.now(tz=self.timezone)))
 
         uid_hash = xxhash.xxh64()
-        uid_hash.update(f"{dtstart}-{url}")
+        uid_hash.update(f"{dtstart}-{url}".encode())
         event.add("uid", uid_hash.hexdigest())
 
         self.cal.add_component(event)


### PR DESCRIPTION
xxhash 4.0.0 (bumped in #172) removed implicit string encoding: xxh64().update()
now raises TypeError: Strings must be encoded before hashing when passed a str
instead of bytes. Encode the UID source string before hashing.